### PR TITLE
Code Climate fixes for Caesar and base classes

### DIFF
--- a/SwiftCrypt/Categories/Int+Crypto.swift
+++ b/SwiftCrypt/Categories/Int+Crypto.swift
@@ -16,7 +16,7 @@ extension Int
     var charValue: Character?
     {
         let s = UnicodeScalar(self)
-        
+
         return s != nil ? Character(s!) : nil
     }
 }

--- a/SwiftCrypt/Ciphers/Caesar.swift
+++ b/SwiftCrypt/Ciphers/Caesar.swift
@@ -49,9 +49,9 @@ class Caesar
             return nil
         }
 
-        var characters:[Character] = Array(input.characters)
+        var characters: [Character] = Array(input.characters)
         let k = Int(key)!
-        var i = 0;
+        var i = 0
 
         for c in input.characters
         {
@@ -73,7 +73,7 @@ class Caesar
                 }
             }
             else { characters[i] = c }
-            
+
             i += 1
         }
 
@@ -180,7 +180,7 @@ extension Caesar: Key
     public static func validate(key: String) -> Bool
     {
         let k = Int(key) ?? -1
-        
+
         return 0 < k && k < 26
     }
 }

--- a/SwiftCryptTests/Categories/Character+CryptoTests.swift
+++ b/SwiftCryptTests/Categories/Character+CryptoTests.swift
@@ -9,9 +9,9 @@
 import XCTest
 @testable import SwiftCrypt
 
-class Character_CryptoTests: XCTestCase
+class CharacterCryptoTests: XCTestCase
 {
-    // MARK: CHARACTER_CRYPTO TESTS
+    // MARK: CHARACTER CRYPTO TESTS
 
     /// Test an ASCII `Character` to `Int` conversion
     ///
@@ -19,7 +19,7 @@ class Character_CryptoTests: XCTestCase
     func asciiValueTest()
     {
         let c: Character = "A"
-        let i = c.asciiValue;
+        let i = c.asciiValue
 
         XCTAssertEqual(i, 65, "ASCII value not generating correctly")
     }

--- a/SwiftCryptTests/Categories/Int+CryptoTests.swift
+++ b/SwiftCryptTests/Categories/Int+CryptoTests.swift
@@ -9,16 +9,16 @@
 import XCTest
 @testable import SwiftCrypt
 
-class Int_CryptoTests: XCTestCase
+class IntCryptoTests: XCTestCase
 {
-    // MARK: CHARACTER_CRYPTO TESTS
+    // MARK: INT CRYPTO TESTS
 
     /// Test an `Int` in the ASCII range to `Character` conversion
     ///
     /// - Author: Bobby Jap
     func charValueTest()
     {
-        let i = 65;
+        let i = 65
         let c = i.charValue
 
         XCTAssertEqual(c, "A", "Character value not generating correctly")

--- a/SwiftCryptTests/Ciphers/CaesarTests.swift
+++ b/SwiftCryptTests/Ciphers/CaesarTests.swift
@@ -24,7 +24,7 @@ class CaesarTests: XCTestCase
         do
         {
             let cipher = try Caesar.encrypt(text: text, withKey: key)
-            
+
             XCTAssertEqual(cipher, "YJXY yjcye!")
         }
         catch
@@ -32,7 +32,7 @@ class CaesarTests: XCTestCase
             XCTFail("Exception shouldn't have been thrown")
         }
     }
-    
+
     /// Test encryption of empty `String`.
     ///
     /// - Author: Bobby Jap


### PR DESCRIPTION
Cleaned up whitespace, semicolons, category test class names, and one documenting typo